### PR TITLE
Update pwned password check to use anonymous endpoint

### DIFF
--- a/home_support.py
+++ b/home_support.py
@@ -1376,20 +1376,29 @@ def Btn_Pwned_Click(Txt_Pwned_Pass):
     Tk.update(top_level)
     
     try:
+        sha1 = hashlib.sha1(Txt_Pwned_Pass.encode()).hexdigest()
+        sha1_prefix = sha1[:5]
+        sha1_suffix = sha1[5:]
+
         opener = urllib2.build_opener()
         opener.addheaders = [('User-Agent', 'UPAT')]
-        r=opener.open("https://haveibeenpwned.com/api/v2/pwnedpassword/"+Txt_Pwned_Pass)
-    
+        r=opener.open("https://api.pwnedpasswords.com/range/"+sha1_prefix)
+
         resp=str(r.getcode())
-        
+
         print resp
-        
-    
+
+
         time_end=datetime.datetime.fromtimestamp(time.time()).strftime('%H:%M:%S')
         w.Txt_Pwned_Output.insert(0.0,time_end+' | '+"Got a response: "+resp+"\n")
-    
+
         if resp=="200":
-            w.Txt_Pwned_Output.insert(0.0,"WARNING!! This password was leaked previously and should not be used anymore.\n")
+            response_content = r.read()
+            if sha1_suffix in response_content:
+                # Password is pwned
+                w.Txt_Pwned_Output.insert(0.0,"WARNING!! This password was leaked previously and should not be used anymore.\n")
+            else:
+                w.Txt_Pwned_Output.insert(0.0,"This password is safe to use.\n")
     
     except urllib2.HTTPError, e:
 


### PR DESCRIPTION
Troy of Have I Been Pwned? has disabled the ability to search by password. Current calls to ```https://haveibeenpwned.com/api/v2/pwnedpassword/``` are probably failing. This PR changes the pwned password check to use the [anonymous endpoint Troy has set up](https://haveibeenpwned.com/API/v2#SearchingPwnedPasswordsByRange). This change is desirable because: 

- The full password to be checked is no longer transferred across the wire.
- The new endpoint has no rate limiting.